### PR TITLE
Fix mismatch when retrieving hourly time series

### DIFF
--- a/R/RFc.R
+++ b/R/RFc.R
@@ -276,8 +276,8 @@ internal_fc.fetchCore <- function(jsonRequest,url,requestProvenance) {
 #' @param lastYear A numeric scalar. Temporal coverage definition: The upper bound of years over which the averaging is performed
 #' @param firstDay A numeric scalar. Temporal coverage definition: The lower bound of the days interval within each year over which the averaging is performed
 #' @param lastDay A numeric scalar. Temporal coverage definition: The upper bound of the days interval within each year over which the averaging is performed
-#' @param startHour A numeric scalar. Temporal coverage definition: The lower bound of the days interval within each year over which the averaging is performed
-#' @param stopHour A numeric scalar. Temporal coverage definition: The upper bound of the days interval within each year over which the averaging is performed
+#' @param startHour A numeric scalar. Temporal coverage definition: The lower bound of the hours interval within each day over which the averaging is performed
+#' @param stopHour A numeric scalar. Temporal coverage definition: The upper bound of the hours interval within each day over which the averaging is performed
 #' @param url The URL of the service to query the data from
 #' @param dataSets A character vector. An identifier of the data set to fetch the data from. The special value "ANY" enables data stitching from all available data sets.
 #' @param reproduceFor A character scalar. A string containing the time for which the result must correspond. The format is "YYYY-MM-DD". The special value "NOW" fetch the data using the latest FetchClimate configuration available.

--- a/R/RFc.R
+++ b/R/RFc.R
@@ -388,11 +388,11 @@ fcTimeSeriesHourly<-function(
         
         years <- c(firstYear,lastYear+1)
         days <- c(firstDay,lastDay+1)
-        hours <- seq(from=startHour,to=stopHour)
+        hours <- seq(from=startHour,to=stopHour+1, by = 1)
         
         resultMatrix <-internal_fc.TimeSeries(variable,latitude,longitude,years,days,hours,url,dataSets,reproduceFor)
         
-        resultMatrix$hours <- hours[1:(length(hours))]
+        resultMatrix$hours <- hours[1:(length(hours)-1)]
         
         return(resultMatrix)
 }

--- a/tests/testthat/test_FcTimeseries.R
+++ b/tests/testthat/test_FcTimeseries.R
@@ -19,12 +19,12 @@ test_that("fcTimeSeriesDaily timeseries correct length for single point", {
 })
 
 test_that("fcTimeSeriesHourly timeseries correct length for single point.", {
-        a<-fcTimeSeriesHourly(variable="airt",latitude=75.1+offset, longitude=57.7,firstYear=1950,lastYear=2000,startHour=0,stopHour=24)
+        a<-fcTimeSeriesHourly(variable="airt",latitude=75.1+offset, longitude=57.7,firstYear=1950,lastYear=2000,startHour=0,stopHour=23)
         expect_equal(ncol(a$values), 24,label=paste("wrong time series length. expected 24 but got",ncol(a$values)))
 })
 
 test_that("fcTimeSeriesHourly timeseries correct length for single point. timestamp set", {
-        a<-fcTimeSeriesHourly(variable="airt",latitude=75.1+offset, longitude=57.7,firstYear=1950,lastYear=2000,startHour=0,stopHour=24,reproduceFor="2015-10-01")
+        a<-fcTimeSeriesHourly(variable="airt",latitude=75.1+offset, longitude=57.7,firstYear=1950,lastYear=2000,startHour=0,stopHour=23,reproduceFor="2015-10-01")
         expect_equal(ncol(a$values), 24,label=paste("wrong time series length. expected 24 but got",ncol(a$values)))
 })
 


### PR DESCRIPTION
When using the function `fcTimeSeriesHourly`, the number of values retrieved (first element of the output list) does not match the length of the `hours` vector (last element in the list). This last vector always has one more element than the number of values, and I think this may be due to a typo in the code. Please have a look.

For example:

```
library(RFc)
hour.ts <- fcTimeSeriesHourly(variable="airt", 
                              latitude = 37.4, longitude = -6,
                              firstYear = 1978, lastYear = 1978,
                              firstDay = 1, lastDay = 1,
                              startHour = 0, stopHour = 23)
str(hour.ts)
```

List of 4
 $ values    : num [1, 1:23] 11 11 11 11 11 11 11 11 11 11 ...
 $ sd        : num [1, 1:23] 2.62e-05 2.62e-05 2.62e-05 2.62e-05 2.62e-05 ...
 $ provenance: Factor w/ 1 level "GHCNv2": 1 1 1 1 1 1 1 1 1 1 ...
 $ hours     : int [1:24] 0 1 2 3 4 5 6 7 8 9 ...
